### PR TITLE
Update broken publication page links

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,9 +42,9 @@ performance that is comparable to statically compiled languages.
 
 </p>
 
-For more information see the <a href="https://juliareach.github.io/Reachability.jl/latest/publications.html">publications page.</a>
+For more information see the <a href="https://juliareach.github.io/Reachability.jl/latest/publications/">publications page.</a>
 Works using JuliaReach related projects can be found in the
-<a href="https://juliareach.github.io/Reachability.jl/latest/citations.html">citations page.</a>
+<a href="https://juliareach.github.io/Reachability.jl/latest/citations/">citations page.</a>
 
         </div>
     </div>


### PR DESCRIPTION
This PR fixes the broken redirects on the main JuliaReach page to the publications and citations respectively.